### PR TITLE
Update requests library to fix CVE-2018-18074.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup_params = dict(
     include_package_data=True,
     description='Memory-efficient caching for the requests library and Python 3',
     long_description=open('README.md').read(),
-    install_requires=['requests~=2.18.4', 'dataclasses~=0.6;python_version<"3.7"'],
+    install_requires=['requests~=2.20.0', 'dataclasses~=0.6;python_version<"3.7"'],
     extras_require={
         'dev': {
             'mockito': '~=1.1.1',


### PR DESCRIPTION
Details:
> moderate severity
> Vulnerable versions: <= 2.19.1
> Patched version: 2.20.0
> The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network. 