### PR TITLE
Feature/teed writer

### DIFF
--- a/cached/__init__.py
+++ b/cached/__init__.py
@@ -5,4 +5,6 @@ __author__ = 'Kenneth VanderLinde'
 __email__ = 'kwvanderlinde@gmail.com'
 __version__ = '0.0.0'
 
+# TODO Get proper logging going instead of print() statements.
+
 from .adapter import CachedHTTPAdapter, create

--- a/cached/adapter.py
+++ b/cached/adapter.py
@@ -48,7 +48,6 @@ class CachedHTTPAdapter(HTTPAdapter):
         entry = self.cache.get(request)
         if entry is None:
             # No valid cached entry. Need to make the request.
-            self.cache.delete(request)  # In case an invalid entry is present.
             requests_response = super().send(requests_request, **kw)
             response = Response(status=requests_response.status_code,
                                 reason=requests_response.reason,

--- a/cached/util.py
+++ b/cached/util.py
@@ -1,7 +1,7 @@
 import dataclasses
 from io import RawIOBase, UnsupportedOperation
 import json
-from typing import io, Sequence, Type
+from typing import Callable, io, Sequence, Type
 
 
 def clamp(value, min, max):
@@ -26,12 +26,16 @@ class DataclassJSONDecoder(json.JSONDecoder):
 
 
 class Tee(RawIOBase):
-    def __init__(self, reader: io.IO[bytes], writer: io.IO[bytes]) -> None:
+    def __init__(self, reader: io.IO[bytes], writer: io.IO[bytes], on_complete: Callable[[], None]) -> None:
         self.__reader = reader
         self.__writer = writer
+        self.__on_complete = on_complete
 
     def _write_chunk(self, chunk: bytes) -> bytes:
         self.__writer.write(chunk)
+        if not chunk:
+            # Indicates EOF was reached in the reader.
+            self.__on_complete()
         return chunk
 
     # region IOBase methods

--- a/cached/util.py
+++ b/cached/util.py
@@ -41,12 +41,8 @@ class Tee(RawIOBase):
     # region IOBase methods
 
     def close(self) -> None:
-        chunk_size = 1024
-        while True:
-            chunk = self.read(chunk_size)
-            if not chunk:
-                break
-        return super().close()
+        self.__reader.close()
+        self.__writer.close()
 
     @property
     def closed(self) -> bool:


### PR DESCRIPTION
Rework the `Tee` file-like object so that it no longer requires reading the entire reader. Instead, when closed, it simply closes the reader and the writer. Also, when EOF is reached in the reader, a callback is now called allowing the user of `Tee` to take actions. In our case we use the callback to finalize the entry.